### PR TITLE
rpm/build.shj脚本增加非root运行脚本立刻退出逻辑

### DIFF
--- a/rpm/build.sh
+++ b/rpm/build.sh
@@ -76,6 +76,7 @@ function get_python()
 {
     if [ `id -u` != 0 ] ; then
         echo "Please use root to run"
+        exit 1
     fi
 
     obd_dir=`dirname $0`


### PR DESCRIPTION
判断逻辑中既然已经提示"Please use root to run"，如果未使用root或sudo权限，是否直接退出脚本执行更为合理？

本pr提交了一个简单退出逻辑，看是否合适。