### PR TITLE
修复issue#111: build.sh脚本中目录切换无效问题

### DIFF
--- a/rpm/build.sh
+++ b/rpm/build.sh
@@ -136,8 +136,8 @@ function build()
     cp -fr ./profile/* /etc/profile.d/
     mv $BUILD_DIR /usr/obd
     rm -fr dist
-    cd $BUILD_DIR/plugins && ln -s oceanbase oceanbase-ce && mv obproxy obproxy-ce
-    cd $BUILD_DIR/config_parser && ln -s oceanbase oceanbase-ce 
+    cd /usr/obd/plugins && ln -s oceanbase oceanbase-ce && mv obproxy obproxy-ce
+    cd /usr/obd/config_parser && ln -s oceanbase oceanbase-ce
     chmod +x /usr/bin/obd
     chmod -R 755 /usr/obd/*
     chown -R root:root /usr/obd/*


### PR DESCRIPTION
将目录修改为/usr/obd/绝对路径。

Fixes #111 